### PR TITLE
Save and restore window size, position and state.

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, dialog } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog, screen } = require('electron');
 const fs = require('fs');
 const path = require('path');
 const shell = require('electron').shell;
@@ -113,6 +113,37 @@ ipcMain.handle('get-rootdir', async (event) => {
   return '';
 }
 );
+
+// BrowserWindow bounds
+ipcMain.handle('set-bounds', async (event, boundsStr) => {
+  try {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    const bounds = JSON.parse(boundsStr);
+    
+    if(win && bounds) {
+      const screenArea = screen.getDisplayMatching(bounds).workArea;
+      
+      if (
+        (bounds.x + bounds.width) > (screenArea.x + screenArea.width) ||
+        bounds.x > (screenArea.x + screenArea.width) || 
+        bounds.x < screenArea.x ||
+        (bounds.y + bounds.height) > (screenArea.y + screenArea.height) ||
+        bounds.y > (screenArea.y + screenArea.height) || 
+        bounds.y < screenArea.y
+      ) {
+          // Fit and center window into the existing screenarea
+          const width = Math.min(bounds.width, screenArea.width);
+          const height = Math.min(bounds.height, screenArea.height);
+          const x = Math.floor((screenArea.width - width) / 2);
+          const y = Math.floor((screenArea.height - height) / 2);
+          win.setBounds({ x: x, y: y, width: width, height: height});
+      }
+      else {
+          win.setBounds(bounds);
+      }
+    }
+  } catch (e) { }
+});
 
 // 通过配置文件获取 modResourceBackpack 文件夹的路径
 

--- a/renderer.js
+++ b/renderer.js
@@ -75,6 +75,16 @@ document.addEventListener('DOMContentLoaded', async () => {
     const initConfigButton = document.getElementById('init-config-button');
     const refreshDialog = document.getElementById('refresh-dialog');
 
+    // Window size and position
+    const bounds = localStorage.getItem('bounds');
+    await ipcRenderer.invoke('set-bounds', bounds);
+
+    // Window fullscreen
+    let isFullScreen = localStorage.getItem('fullscreen') === 'true';
+    if(isFullScreen) {
+        toggleFullscreen();
+    }
+
     //- 初始化
     // 检测是否是第一次打开
     const firstOpen = localStorage.getItem('firstOpen');
@@ -569,8 +579,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
     //-全屏按钮
-    fullScreenButton.addEventListener('click', async () => {
-        const isFullScreen = await ipcRenderer.invoke('toggle-fullscreen');
+    fullScreenButton.addEventListener('click', toggleFullscreen);
+
+    async function toggleFullscreen() {
+        isFullScreen = await ipcRenderer.invoke('toggle-fullscreen');
         if (!isFullScreen) {
             fullScreenSvgpath.setAttribute('d', 'M120-120v-200h80v120h120v80H120Zm520 0v-80h120v-120h80v200H640ZM120-640v-200h200v80H200v120h-80Zm640 0v-120H640v-80h200v200h-80Z');
         }
@@ -578,8 +590,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             fullScreenSvgpath.setAttribute('d', 'M240-120v-120H120v-80h200v200h-80Zm400 0v-200h200v80H720v120h-80ZM120-640v-80h120v-120h80v200H120Zm520 0v-200h80v120h120v80H640Z');
         }
     }
-    );
-
 
     //-setting-dialog相关
     rootdirConfirmButton.addEventListener('click', async () => {
@@ -949,5 +959,18 @@ document.addEventListener('DOMContentLoaded', async () => {
         saveCurrentModInfo();
         //关闭对话框
         editModInfoDialog.dismiss();
+    });
+
+    window.addEventListener('unload', function(event) {
+        localStorage.setItem('fullscreen', isFullScreen);
+
+        if(!isFullScreen) {
+            localStorage.setItem('bounds', JSON.stringify({
+                x: window.screenX,
+                y: window.screenY,
+                width: window.outerWidth,
+                height: window.innerHeight,
+            }));
+        }
     });
 });


### PR DESCRIPTION
Hello, i was enyojing your manager and figured i could contribute some improvements  👍 

- Saves the window position, size and state (fullscreen or not) when you close the manager.
- Restores those values when you open the manager again. 

This tries to fit the window inside the screen in case you change or disconnect monitors, manually move the window off the screen, etc. Persist the data in localstorage as everything else. As a suggestion, i would change localstorage with a settings file in the future.
That way you could directly load the information in main and create the window with those properties from the start, instead of creating the window, reading from localstorage in renderer, and changing the window back in main.

Thank you