### PR TITLE
Use fs to create symlinks for all platforms

### DIFF
--- a/main.js
+++ b/main.js
@@ -222,9 +222,9 @@ ipcMain.handle('apply-mods', async (event, mods) => {
       // );
       // //fs.cpSync(src, dest, { recursive: true });
       //这里不再复制文件夹，而是创建一个快捷方式，使用cmd的mklink命令
-      const cmd = `mklink /J "${dest}" "${src}"`;
-      //console.log(`cmd: ${cmd}`);
-      require('child_process').execSync(cmd);
+      fs.symlinkSync(src, dest, 'junction', (err) => {
+        if (err) console.log(err);
+      });
     }
   });
 });


### PR DESCRIPTION
What this changes:
Instead of manually executing the windows mklink command, use the file system node module symlinkSync function.

Why:
Even thoguh you only provide a windows release, this allows the manager to work in other platforms, like linux and mac.
I personally package and use the manager in both windows and linux, and with this small change, it works without issues.

Tested on both platforms.
Let me know what you think or if you encounter any issues.