### PR TITLE
Configure github actions to create draft releases when pushing tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,52 +2,37 @@ name: Build
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*'
   workflow_dispatch:
   
 jobs:
   release:
     name: build and release electron app
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os.image }}
 
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest]
+        os:
+          [
+            { name: 'linux', image: 'ubuntu-latest' },
+            { name: 'windows', image: 'windows-latest' },
+          ]
 
     steps:
       - name: Check out git repository
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v4
 
       - name: Install Node.js
-        uses: actions/setup-node@v3.0.0
+        uses: actions/setup-node@v4
         with:
-          node-version: "16"
+          node-version: "20"
 
       - name: Install Dependencies
-        run: npm install
+        run: npm ci
 
-      - name: Build Electron App
-        run: npm run dist
+      - name: Publish Electron App
+        run: npm run publish
         env:
-          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-
-      - name: Cleanup Artifacts for Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          npx rimraf "dist/!(*.exe)"
-      
-      - name: upload artifacts
-        uses: actions/upload-artifact@v3.0.0
-        with:
-          name: ${{ matrix.os }}
-          path: dist
-
-      - name: release
-        uses: softprops/action-gh-release@v0.1.14
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: "dist/**"
-        env:
-          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/forge.config.js
+++ b/forge.config.js
@@ -1,5 +1,4 @@
 const { FusesPlugin } = require('@electron-forge/plugin-fuses');
-const { default: PublisherGithub } = require('@electron-forge/publisher-github');
 const { FuseV1Options, FuseVersion } = require('@electron/fuses');
 
 module.exports = {
@@ -16,15 +15,19 @@ module.exports = {
     },
     {
       name: '@electron-forge/maker-zip',
-      platforms: ['darwin'],
+      platforms: ['darwin', 'linux', 'win32'],
     },
     {
       name: '@electron-forge/maker-deb',
-      config: {},
+      config: {
+        bin: 'ZZZModManager',
+      }
     },
     {
       name: '@electron-forge/maker-rpm',
-      config: {},
+      config: {
+        bin: 'ZZZModManager',
+      }
     },
   ],
   plugins: [
@@ -52,7 +55,6 @@ module.exports = {
           owner: 'xiaolinxiaozhu',
           name: 'mods-manager-for-3dmigoto'
         },
-        prerelease: false,
         draft: true
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mods-manager-for-3dmigoto",
-  "version": "1.0.0",
+  "version": "1.8.1",
   "description": "这是一个便捷的mod管理工具。该工具会自动加载位于文件夹根目录的 `mods` 文件夹内的插件。通过将插件根据需求移动到 `mods` 文件夹来实现插件的启用和禁用。",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Hello, as requested, i've been looking into getting the github actions working. Let's hope this fixes the workflow.

I've actually never used github actions before but after [some](https://sevic.dev/notes/electron-forge-publish-github/) [research](https://dev.to/erikhofer/build-and-publish-a-multi-platform-electron-app-on-github-3lnd) and a fair share of trial and error, I was able to get releases [on my fork](https://github.com/soliddanii/Mods-Manager-for-3Dmigoto/releases/tag/v1.8.4).

Some notes about the configuration:
- I changed ACCESS_TOKEN with GITHUB_TOKEN because thats what i saw in the documentation. The github token is a token automatically generated by github for each action with the appropiate permissions. Here is the [relevant documentation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#about-the-github_token-secret)
- This configuration builds the application and generates a DRAFT release when a new tag is pushed, insteaf of on every push. You can trigger the action manually too. More on that later.
- Both windows and linux builds get generated. The zip file is the same as the manual release you were currently doing. I did test the windows zip release and encountered no issues. Did not test the .deb or .rpm packages due to a lack of time. I also want to research into packaging as AppImage as that is my prefered linux format.
- Upgraded the node version to the latest LTS, but feel free to change it if another version is needed for some reason.

Now, this is the easiest way I found to make new releases:
- After commiting the changes for a new version, run `npm version major|minor|patch` to automatically change the package.json version, and generate the tag. Here is the [npm version documentation.](https://docs.npmjs.com/cli/v6/commands/npm-version). For example, if package version is 1.8.1, and you run `npm version patch`, It will change to 1.8.2. If you run `npm version minor`, it will change to 1.9.0
- Then, push both the version change and the tag with: `git push --follow-tags`. Of course you can also generate the tags manually.
- Wait a few minutes to let the actions finish, then you will see the draft release with the artifacts. Just click on the edit button of the draft release to setup the description and discard/add any artifacts.


Let me know if you encounter any issues or want to suggest any change 👍 