### PR TITLE
Refresh in ZZZ

### DIFF
--- a/index.html
+++ b/index.html
@@ -474,7 +474,7 @@
             <s-switch id="auto-apply-switch"></s-switch>
           </div>
         </div>
-        <div id="test-function">
+        <div id="test-function" data-platform="win32">
           <h3 data-translate-key="test-title"> 测试功能 </h3>
           <div
             style="display: flex;flex-direction: row;align-items: center;align-content: center;justify-content: space-between;">

--- a/index.html
+++ b/index.html
@@ -474,11 +474,11 @@
             <s-switch id="auto-apply-switch"></s-switch>
           </div>
         </div>
-        <div id="test-funciton">
+        <div id="test-function">
           <h3 data-translate-key="test-title"> 测试功能 </h3>
           <div
             style="display: flex;flex-direction: row;align-items: center;align-content: center;justify-content: space-between;">
-            <p data-translate-key="test-funciton-info">启用 应用mod时 将会自动在绝区零中激活刷新(*需要使用管理员权限打开)</p>
+            <p data-translate-key="test-function-info">启用 应用mod时 将会自动在绝区零中激活刷新(*需要使用管理员权限打开)</p>
             <s-switch id="auto-refresh-in-zzz"></s-switch>
           </div>
           <p data-translate-key="dialog-ask-for-exePath">因为文件结构限制，这里需要您手动指定refresh-in-zzz.exe，它一般位于和ZZZModManager同一目录下

--- a/locales/en.json
+++ b/locales/en.json
@@ -29,7 +29,7 @@
     "auto-apply": "Auto Apply",
     "auto-apply-info": "Automatically apply configuration when selecting/deselecting mods (may cause slight lag)",
     "test-title": "Test Function",
-    "test-funciton-info": "When applying mods, the refresh in the zero area will be activated automatically(*Need to open with administrator privileges), there still have bugs and is not recommended for use",
+    "test-function-info": "When applying mods, the refresh in the zero area will be activated automatically(*Need to open with administrator privileges), there still have bugs and is not recommended for use",
     "dialog-ask-for-exePath": "Due to file structure restrictions, you need to manually specify refresh-in-zzz.bat here, which is generally located in the same directory as ZZZModManager",
     "save-change": "Save Changes",
     "dialog-ask-for-save-change": "Detected unsaved changes, save them?",

--- a/locales/zh-cn.json
+++ b/locales/zh-cn.json
@@ -29,7 +29,7 @@
   "auto-apply": "自动应用",
   "auto-apply-info": "当选择/取消选择mod时自动应用配置(可能带来轻微卡顿)",
   "test-title": "测试功能",
-  "test-funciton-info":"启用 应用mod时 将会自动在绝区零中激活刷新(*需要使用管理员权限打开)(存在bug,不建议使用)",
+  "test-function-info":"启用 应用mod时 将会自动在绝区零中激活刷新(*需要使用管理员权限打开)(存在bug,不建议使用)",
   "dialog-ask-for-exePath": "因为文件结构限制，这里需要您手动指定refresh-in-zzz.bat，它一般位于和ZZZModManager同一目录下",
   "save-change": "保存修改",
   "dialog-ask-for-save-change": "检测到您有未保存的修改，是否保存？",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "electron-squirrel-startup": "^1.0.1",
+        "hmc-win32": "^1.4.92",
         "sober": "^0.2.21"
       },
       "devDependencies": {
@@ -3540,6 +3541,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hmc-win32": {
+      "version": "1.4.92",
+      "resolved": "https://registry.npmjs.org/hmc-win32/-/hmc-win32-1.4.92.tgz",
+      "integrity": "sha512-KGnLuCLHupjT2D3SAujqd6ozEBmCM5UkO8Og2SDFQE+9FBSujJdI6XHLvEtSN39JMR4GEcXfgUyOy4r4BiPv/Q==",
+      "engines": {
+        "node": ">= 6.14.2"
       }
     },
     "node_modules/homedir-polyfill": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "electron-squirrel-startup": "^1.0.1",
+    "hmc-win32": "^1.4.92",
     "sober": "^0.2.21"
   }
 }

--- a/renderer-preload.js
+++ b/renderer-preload.js
@@ -1,4 +1,4 @@
-const { ipcRenderer, remote, contextBridge } = require('electron');
+const { ipcRenderer, remote } = require('electron');
 const path = require('path');
 const os = require('os');
 const fs = require('fs');

--- a/renderer-preload.js
+++ b/renderer-preload.js
@@ -1,6 +1,7 @@
-const { ipcRenderer, remote } = require('electron');
+const { ipcRenderer, remote, contextBridge } = require('electron');
 const path = require('path');
+const os = require('os');
 const fs = require('fs');
 // 获取是否是第一次打开
 
-
+window.platform = os.platform();

--- a/renderer.js
+++ b/renderer.js
@@ -104,6 +104,15 @@ document.addEventListener('DOMContentLoaded', async () => {
         toggleFullscreen();
     }
 
+    // Hide platform specific components if not current platform
+    document.querySelectorAll("[data-platform]").forEach(element => {
+        const platforms = element.dataset.platform.split(",");
+
+        if(!platforms.includes(window.platform)) {
+            element.style.display = "none";
+        }
+    });
+
     // 创建 Intersection Observer
     // 用于检测modItem是否在视窗内,如果在视窗内则使其inWindow属性为true,否则为false
     // 用来代替 getBoundingClientRect() 来判断元素是否在视窗内,getBoundingClientRect()会导致页面重绘
@@ -177,7 +186,9 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         //如果启用了 auto-refresh-in-zzz 则使用cmd激活刷新的exe程序
         if (ifAutofreshInZZZ) {
-            tryRefreshInZZZ();
+            ipcRenderer.invoke('refresh-in-zzz').then(result => {
+                result && snack('Successfully refreshed in ZZZ');
+            });
         }
     }
 
@@ -1156,40 +1167,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         //使用s-snackbar显示提示
         snack('Mods applied');
     })
-
-    async function tryRefreshInZZZ() {
-        //尝试刷新,使用async，防止阻塞
-        //使用cmd激活刷新的exe程序
-        if (exePath === '') {
-            console.log("exePath is empty");
-            return '';
-        }
-
-        const cmd = `start "" "${exePath}" /min`;
-        let stdout;
-        console.log(`cmd: ${cmd}`);
-
-        try {
-            // 执行exe程序
-            stdout = require('child_process').execSync(cmd, { encoding: 'utf-8' });
-            console.log('stdout:', stdout);
-            // 如果没有抛出异常，说明程序正常退出，退出状态码为0
-            console.log('程序正常退出，退出状态码: 0');
-        } catch (error) {
-            // 如果程序非正常退出，这里可以捕获到错误
-            if (error.status) {
-                console.error(`程序非正常退出，退出状态码: ${error.status}`);
-            } else {
-                // 处理其他类型的错误
-                console.error('发生了一个错误：', error.message);
-            }
-        }
-
-        console.log(`succeed to execute ${cmd}，refresh-in-zzz.exe return: ${stdout}`);
-        snack('Successfully refresh in ZZZ' + stdout);
-
-        return exePath;
-    }
 
     const unknownModConfirmButton = document.getElementById('unknown-mod-confirm');
     const unknownModIgnoreButton = document.getElementById('unknown-mod-ignore');


### PR DESCRIPTION
I made two solutions in two different branches (named after the packages they use):

1. [Hmc-win32](https://github.com/soliddanii/Mods-Manager-for-3Dmigoto/tree/feature/refresh-in-zzz-hmc-win32) (this merge request)
2. [Koffi](https://github.com/soliddanii/Mods-Manager-for-3Dmigoto/tree/feature/refresh-in-zzz-koffi)

Both solutions use almost the same Windows libraries and APIs, and that's why they are fast, but the [hmc-win32](https://github.com/kihlh/hmc-win32) solution has way simpler code as it abstracts a lot of the manual work. That's why I made the MR for that branch first, but I'll let you decide which solution you want, if any, as they both have their pros and cons. You could even combine both later.

[Hmc-win32](https://github.com/kihlh/hmc-win32) can't send the keystrokes directly to the game. This is because it sends **Virtual Keys**, and in my experience ZZZ ignores them. It only works if you send **Direct Input** Keystrokes. Maybe in the future the package supports it, that would be ideal. To circumvent this issue, i thought of a trick to get the key in the game without sending it directly to the window, that way this solution **does not require admin privileges** either. In summary [this is how it works](https://github.com/soliddanii/Mods-Manager-for-3Dmigoto/blob/e759aae4bc4a4a8b4096240d2a65b0a5e2c58fe9/main.js#L299):

1. Press the key down **in the manager**
2. Focus on the game window
3. Wait for the input to register
4. Focus on the manager window again
5. Release the key
6. Focus back on the game.

It's fast enough, but it's not the smoothest experience. Here I _get the game window through the process name_.

Now for the [Koffi](https://github.com/Koromix/koffi) solution. This is a really amazing package. You have to manually call every Windows function, and define C++ structs and types, but the possibilities are endless. [With this code](https://github.com/soliddanii/Mods-Manager-for-3Dmigoto/blob/feature/refresh-in-zzz-koffi/refresh-in-zzz.js), I actually send the Direct Input key to the game window, as it should be. The downside, you **must run the manager as admin**, or it doesn't work. This solution tries to _get the game window from the process name first, and if it fails, it tries with the window name_.

I would suggest to give both branches a test, see if they work for you (as I don't know how it will behave in other machines), and I will let you decide what to do with the code.

Maybe use one over the other, or even pick and choose the code to use a combination of the two (if that were the case, I would personally use the hmc-win32 way of getting the game window, and then, if the manager is running as admin, use the sendinput function from Koffi; if it's not, use the trick). Hmc has the useful function HMC.isAdmin().

Some additional notes:

1. I did not remove any extra code related to the previous solution. I you end up merging one of these, I'll leave that task to you.
2. This will only work on windows, for obvious reasons. Having a way to hide the related settings in other platforms would be great. That's why I included some code to hide html components depending on the platform. [This is how you use it](https://github.com/soliddanii/Mods-Manager-for-3Dmigoto/blob/e759aae4bc4a4a8b4096240d2a65b0a5e2c58fe9/index.html#L477). Just add a data-platform attribute with the allowed platforms separated by commas (that is win32, linux and darwin).
3. I personally liked the simpler design for the side panels, but that totally comes down to personal preference. You could maybe have the top panel reach both sides and have the side panels below it. That way you could have the buttons in a more traditional position in the top right for example. Just an idea.
4. The dedicated mod url field is great! I was actually saving the urls in the description before 🤣 .

Anyway, I hope some of this is useful to you, and congrats on the manager progress! 😄 